### PR TITLE
Remove title attr from Kanban sections (columns)

### DIFF
--- a/libs/Pink/Data/Kanban/1/tpl.html
+++ b/libs/Pink/Data/Kanban/1/tpl.html
@@ -1,6 +1,6 @@
 <div class="pink-kanban pink-disable-text-selection">
     <!--ko foreach: {data: sections, afterRender: afterRender} -->
-    	<div data-bind="css: (typeof css=='undefined'?'pink-section':'pink-section '+ko.unwrap(css)), attr: {title: $data.title}">
+    	<div data-bind="css: (typeof css=='undefined'?'pink-section':'pink-section '+ko.unwrap(css))">
     		<div class="pink-title prevent-hover-propagation">
                 <!--ko if: (typeof headerTemplate=='undefined')-->
                     <div data-bind="text: title"></div>


### PR DESCRIPTION
During usability testing it was observed that the title tooltip
interferes with the reading of tasks while the task is hovered.
